### PR TITLE
fix: use node to prevent extraneous output when running script

### DIFF
--- a/.github/workflows/check-unity-sdk-for-updates.yml
+++ b/.github/workflows/check-unity-sdk-for-updates.yml
@@ -6,6 +6,9 @@ on:
       - main
   schedule: # Run Daily
     - cron: '0 0 * * *'
+  pull_request:
+    branches:
+      - dakota/fix-file-permissions
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/check-unity-sdk-for-updates.yml
+++ b/.github/workflows/check-unity-sdk-for-updates.yml
@@ -6,9 +6,11 @@ on:
       - main
   schedule: # Run Daily
     - cron: '0 0 * * *'
-  pull_request:
-    branches:
-      - dakota/fix-file-permissions
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/check-unity-sdk-for-updates.yml
+++ b/.github/workflows/check-unity-sdk-for-updates.yml
@@ -6,11 +6,6 @@ on:
       - main
   schedule: # Run Daily
     - cron: '0 0 * * *'
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
   workflow_dispatch:
 
 jobs:
@@ -34,7 +29,7 @@ jobs:
 
       - name: Check for AdGem SDK updates
         run: |
-          LATEST_VERSION=$(npm run check-adgem-version)
+          LATEST_VERSION=$(node ./bin/check-for-updates.js)
           if [ $? -ne 0 ]; then
             echo "Failed to get latest SDK version"
             exit 1
@@ -50,7 +45,7 @@ jobs:
           git config --global user.name "${{ vars.BOT_NAME || 'adgem-developers' }}"
           git config --global user.email "${{ vars.BOT_EMAIL || 'developers@adgem.com' }}"
           git add .
-          git commit -m 'build: update adgem sdk dependency version'
+          git commit -m 'fix(deps): update adgem sdk dependency version'
           git push origin HEAD:refs/heads/update-adgem-sdk-$LATEST_ANDROID_SDK_VERSION
 
       - name: Create Pull Request

--- a/Editor/Android/AdGemDependencies.xml
+++ b/Editor/Android/AdGemDependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <dependencies>
   <androidPackages>
-    <androidPackage spec="com.adgem:adgem-android:v4.0.2">
+    <androidPackage spec="com.adgem:adgem-android:4.0.2">
       <androidSdkPackageIds>
         <androidSdkPackageId>extra-google-m2repository</androidSdkPackageId>
       </androidSdkPackageIds>

--- a/Editor/Android/AdGemDependencies.xml
+++ b/Editor/Android/AdGemDependencies.xml
@@ -1,15 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <dependencies>
-    <androidPackages>
-        <androidPackage spec="com.adgem:adgem-android:4.0.1">
-            <androidSdkPackageIds>
-                <androidSdkPackageId>extra-google-m2repository</androidSdkPackageId>
-            </androidSdkPackageIds>
-            <repositories>
-                <repository>https://maven.google.com</repository>
-            </repositories>
-        </androidPackage>
-    </androidPackages>
-    <iosPods>
-        <iosPod name="AdGem"/>
-    </iosPods>
+  <androidPackages>
+    <androidPackage spec="com.adgem:adgem-android:v4.0.2">
+      <androidSdkPackageIds>
+        <androidSdkPackageId>extra-google-m2repository</androidSdkPackageId>
+      </androidSdkPackageIds>
+      <repositories>
+        <repository>https://maven.google.com</repository>
+      </repositories>
+    </androidPackage>
+  </androidPackages>
+  <iosPods>
+    <iosPod name="AdGem"/>
+  </iosPods>
 </dependencies>

--- a/bin/check-for-updates.js
+++ b/bin/check-for-updates.js
@@ -38,6 +38,8 @@ async function checkAdGemSdkUpdates() {
     const updatedXmlContent = builder.buildObject(xml);
     fs.writeFileSync(configFilePath, updatedXmlContent);
   }
+
+  console.log(latestVersion);
 }
 
 checkAdGemSdkUpdates();

--- a/bin/check-for-updates.js
+++ b/bin/check-for-updates.js
@@ -29,7 +29,8 @@ async function checkAdGemSdkUpdates() {
     }
   });
 
-  const latestVersion = response.data.tag_name;
+  let latestVersion = response.data.tag_name;
+  latestVersion = latestVersion.replace(/^v/, ''); // Remove leading 'v'
 
   if (latestVersion !== currentVersion) {
     // Update the AdGemDependencies.xml with the new version

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "email": "info@adgem.com",
     "url": "https://adgem.com/"
   },
-  "scripts": {
-    "check-adgem-version": "node ./bin/check-for-updates.js"
-  },
   "samples": [
     {
       "displayName": "AdGemDemo",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated workflow for checking AdGem SDK updates using a Node.js script.
	- Version of the `adgem-android` package updated to `v4.0.2`.
	- Added logging for the latest AdGem SDK version during update checks.

- **Bug Fixes**
	- Improved responsiveness of SDK update checks in relation to pull request modifications.

- **Chores**
	- Removed obsolete script for checking AdGem version from `package.json`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->