### PR TITLE
feat: add explicit pod version for ios

### DIFF
--- a/Editor/Android/AdGemDependencies.xml
+++ b/Editor/Android/AdGemDependencies.xml
@@ -11,6 +11,6 @@
     </androidPackage>
   </androidPackages>
   <iosPods>
-    <iosPod name="AdGem"/>
+    <iosPod name="AdGem" version="2.0.0"/>
   </iosPods>
 </dependencies>


### PR DESCRIPTION
This PR sets AdGem iOS SDK pod version explicitly in [AdGemDependencies.xml](https://github.com/AdGem/adgem-sdk-unity-package/blob/42ca47e6dea7e97a5b704747c92bcba6f009e190/Editor/Android/AdGemDependencies.xml) so that CI can later track it updates automatically.

Related to #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the AdGem integration to version 2.0.0 for improved performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->