### PR TITLE
feat: add functionality to update self-owned repository release version references in different parts of our code

### DIFF
--- a/.github/workflows/check-unity-sdk-for-updates.yml
+++ b/.github/workflows/check-unity-sdk-for-updates.yml
@@ -27,19 +27,27 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Check for AdGem SDK updates
+      - name: Get latest AdGem Android SDK updates
+        env:
+          CHECK_TYPE: 'self'
+          GITHUB_TOKEN: ${{ secrets.ADGEM_SDK_ACTIONS_TOKEN }}
         run: |
-          LATEST_VERSION=$(node ./bin/check-for-updates.js)
-          if [ $? -ne 0 ]; then
-            echo "Failed to get latest SDK version"
+          if ! LATEST_VERSION=$(node ./bin/check-for-updates.js); then
+            echo "Error: Failed to get latest SDK version. Please check the script output above for details."
             exit 1
           fi
           echo "LATEST_ANDROID_SDK_VERSION=$LATEST_VERSION" >> "$GITHUB_ENV"
           echo "HAS_CHANGES=$(git status --porcelain -z | tr '\0' ' ')" >> "$GITHUB_ENV"
-        env:
-          CHECK_TYPE: 'self'
-          GITHUB_TOKEN: ${{ secrets.ADGEM_SDK_ACTIONS_TOKEN }}
-
+      - name: Update Android Manifest File
+        if: env.HAS_CHANGES
+        run: |
+          set -e
+          BRANCH_NAME="update-adgem-sdk-${LATEST_ANDROID_SDK_VERSION}-$(date +%s)"
+          
+          if ! sed -i "s|implementation 'com.adgem.android:adgem-sdk:.*'|implementation 'com.adgem.android:adgem-sdk:${LATEST_ANDROID_SDK_VERSION}'|g" AndroidManifest.xml; then
+            echo "Error: Failed to update AndroidManifest.xml"
+            exit 1
+          fi
       - name: Commit and push changes
         if: env.HAS_CHANGES
         run: |

--- a/.github/workflows/check-unity-sdk-for-updates.yml
+++ b/.github/workflows/check-unity-sdk-for-updates.yml
@@ -37,6 +37,7 @@ jobs:
           echo "LATEST_ANDROID_SDK_VERSION=$LATEST_VERSION" >> "$GITHUB_ENV"
           echo "HAS_CHANGES=$(git status --porcelain -z | tr '\0' ' ')" >> "$GITHUB_ENV"
         env:
+          CHECK_TYPE: 'self'
           GITHUB_TOKEN: ${{ secrets.ADGEM_SDK_ACTIONS_TOKEN }}
 
       - name: Commit and push changes

--- a/.github/workflows/update-self-version-reference.yml
+++ b/.github/workflows/update-self-version-reference.yml
@@ -45,11 +45,20 @@ jobs:
           echo "LATEST_VERSION=$LATEST_VERSION" >> "$GITHUB_ENV"
       - name: Update README.md
         run: |
-          sed -i "s|https://github.com/AdGem/adgem-sdk-unity-package.git#.*|https://github.com/AdGem/adgem-sdk-unity-package.git#$LATEST_VERSION|g" README.md
+          set -e
+          BRANCH_NAME="update-unity-package-url-${LATEST_VERSION}-$(date +%s)"
+          
+          if ! sed -i "s|https://github.com/AdGem/adgem-sdk-unity-package.git#.*|https://github.com/AdGem/adgem-sdk-unity-package.git#${LATEST_VERSION}|g" README.md; then
+            echo "Error: Failed to update README.md"
+            exit 1
+          fi
+          
           git add README.md
-          git commit -m "chore: update Unity package URL to version $LATEST_VERSION"
-          git push origin HEAD:update-unity-package-url-$LATEST_VERSION
-
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git commit -m "chore: update Unity package URL to version ${LATEST_VERSION}"
+          git push origin "HEAD:${BRANCH_NAME}"
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.github/workflows/update-self-version-reference.yml
+++ b/.github/workflows/update-self-version-reference.yml
@@ -1,0 +1,64 @@
+name: Update Unity Package URL
+# Check out the repository.
+# Set up Node.js.
+# Install dependencies.
+# Get the latest version of the package using a Node.js script.
+# Update the README.md file with the new version.
+# Commit and push the changes to a new branch.
+# Create a pull request for the changes.
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Get latest version
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADGEM_SDK_ACTIONS_TOKEN }}
+          CHECK_TYPE: 'self'
+        run: |
+          LATEST_VERSION=$(node ./bin/check-for-updates.js)
+          if [ $? -ne 0 ]; then
+            echo "Failed to get latest SDK version"
+            exit 1
+          fi
+          echo "LATEST_VERSION=$LATEST_VERSION" >> "$GITHUB_ENV"
+
+      - name: Update README.md
+        run: |
+          sed -i "s|https://github.com/AdGem/adgem-sdk-unity-package.git#.*|https://github.com/AdGem/adgem-sdk-unity-package.git#$LATEST_VERSION|g" README.md
+          git add README.md
+          git commit -m "chore: update Unity package URL to version $LATEST_VERSION"
+          git push origin HEAD:update-unity-package-url-$LATEST_VERSION
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update-unity-package-url-${{ env.LATEST_VERSION }}
+          title: 'chore: update Unity package URL to version ${{ env.LATEST_VERSION }}'
+          body: |
+            This PR updates the Unity package URL in the README.md file to the latest version.
+          labels: 'automated pr'
+          team-reviewers: adgem/sdk-team

--- a/.github/workflows/update-self-version-reference.yml
+++ b/.github/workflows/update-self-version-reference.yml
@@ -63,7 +63,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.ADGEM_SDK_ACTIONS_TOKEN }}
-          branch: update-unity-package-url-${{ env.LATEST_VERSION }}
+          branch: ${{ env.BRANCH_NAME }}
           title: 'chore: update Unity package URL to version ${{ env.LATEST_VERSION }}'
           body: |
             This PR updates the Unity package URL in the README.md file to the latest version.

--- a/.github/workflows/update-self-version-reference.yml
+++ b/.github/workflows/update-self-version-reference.yml
@@ -1,4 +1,9 @@
 name: Update Unity Package URL
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Check out the repository.
 # Set up Node.js.
 # Install dependencies.
@@ -6,7 +11,6 @@ name: Update Unity Package URL
 # Update the README.md file with the new version.
 # Commit and push the changes to a new branch.
 # Create a pull request for the changes.
-
 on:
   push:
     branches:

--- a/.github/workflows/update-self-version-reference.yml
+++ b/.github/workflows/update-self-version-reference.yml
@@ -15,6 +15,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   update-readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-self-version-reference.yml
+++ b/.github/workflows/update-self-version-reference.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.ADGEM_SDK_ACTIONS_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -36,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get latest version
+      - name: Get latest AdGem Unity SDK version
         env:
           GITHUB_TOKEN: ${{ secrets.ADGEM_SDK_ACTIONS_TOKEN }}
           CHECK_TYPE: 'self'
@@ -46,34 +47,53 @@ jobs:
             exit 1
           fi
           echo "LATEST_VERSION=$LATEST_VERSION" >> "$GITHUB_ENV"
+          echo "HAS_CHANGES=$(git status --porcelain -z | tr '\0' ' ')" >> "$GITHUB_ENV"
+          echo "Latest version: $LATEST_VERSION"
       - name: Update README.md
+        if: env.HAS_CHANGES
         run: |
           set -e
-          BRANCH_NAME="update-unity-package-url-${LATEST_VERSION}-$(date +%s)"
           
           if ! sed -i "s|https://github.com/AdGem/adgem-sdk-unity-package.git#.*|https://github.com/AdGem/adgem-sdk-unity-package.git#${LATEST_VERSION}|g" README.md; then
             echo "Error: Failed to update README.md"
             exit 1
           fi
-          
-          git add README.md
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git commit -m "chore: update Unity package URL to version ${LATEST_VERSION}"
-          git push origin "HEAD:${BRANCH_NAME}"
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
+      - name: Update package.json dependency
+        if: env.HAS_CHANGES
+        run: |
+            set -e
+            if ! sed -i "s|\"adgem-sdk-unity-package\": \".*\"|\"adgem-sdk-unity-package\": \"${LATEST_VERSION}\"|g" package.json; then
+                echo "Error: Failed to update package.json"
+                exit 1
+            fi
       - name: Verify file changes
+        if: env.HAS_CHANGES
         run: |
           if ! grep -q "adgem-sdk-unity-package.git#${LATEST_VERSION}" README.md; then
             echo "Error: README.md was not updated"
             exit 1
           fi
+          if ! grep -q "version": "${LATEST_VERSION}" package.json; then
+            echo "Error: package.json was not updated"
+            exit 1
+          fi
+      - name: Commit and push changes
+        if: env.HAS_CHANGES
+        run: |
+          BRANCH_NAME="update-unity-package-url-${LATEST_VERSION}-$(date +%s)"
+          git add README.md package.json
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git commit -m "chore: update Unity package URL to version ${LATEST_VERSION}"
+          git push origin "HEAD:${BRANCH_NAME}"
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
       - name: Create Pull Request
+        if: env.HAS_CHANGES
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.ADGEM_SDK_ACTIONS_TOKEN }}
           branch: ${{ env.BRANCH_NAME }}
-          title: 'chore: update Unity package URL to version ${{ env.LATEST_VERSION }}'
+          title: 'build: update Unity package URL to version ${{ env.LATEST_VERSION }}'
           body: |
             This PR updates the Unity package URL in the README.md file to the latest version.
           labels: 'automated pr'

--- a/.github/workflows/update-self-version-reference.yml
+++ b/.github/workflows/update-self-version-reference.yml
@@ -62,6 +62,12 @@ jobs:
           git commit -m "chore: update Unity package URL to version ${LATEST_VERSION}"
           git push origin "HEAD:${BRANCH_NAME}"
           echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
+      - name: Verify file changes
+        run: |
+          if ! grep -q "adgem-sdk-unity-package.git#${LATEST_VERSION}" README.md; then
+            echo "Error: README.md was not updated"
+            exit 1
+          fi
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.github/workflows/update-self-version-reference.yml
+++ b/.github/workflows/update-self-version-reference.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ADGEM_SDK_ACTIONS_TOKEN }}
           branch: update-unity-package-url-${{ env.LATEST_VERSION }}
           title: 'chore: update Unity package URL to version ${{ env.LATEST_VERSION }}'
           body: |

--- a/bin/check-for-updates.js
+++ b/bin/check-for-updates.js
@@ -64,10 +64,6 @@ async function checkOwnRepoUpdates() {
   console.log(latestVersion);
 }
 
-console.log('Checking for updates...');
-console.log('Github Token:', GITHUB_TOKEN);
-console.log('Check Type:', CHECK_TYPE);
-
 if (CHECK_TYPE === 'external') {
   checkExternalUpdates();
 } else if (CHECK_TYPE === 'self') {

--- a/bin/check-for-updates.js
+++ b/bin/check-for-updates.js
@@ -5,22 +5,20 @@ const xml2js = require('xml2js');
 
 // Read the GitHub token from the environment variable
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const CHECK_TYPE = process.env.CHECK_TYPE || 'external'; // Default to 'external' if not set
 
 if (!GITHUB_TOKEN) {
   console.error('Error: GitHub token is not set in the environment variables.');
   process.exit(1);
 }
 
-const configFilePath = path.join(__dirname, '../Editor/Android/AdGemDependencies.xml');
-
-async function checkAdGemSdkUpdates() {
-  // Read the current version from AdGemDependencies.xml
+async function checkExternalUpdates() {
+  const configFilePath = path.join(__dirname, '../Editor/Android/AdGemDependencies.xml');
   const xmlContent = fs.readFileSync(configFilePath, 'utf8');
   const parser = new xml2js.Parser();
   const xml = await parser.parseStringPromise(xmlContent);
   const currentVersion = xml.dependencies.androidPackages[0].androidPackage[0].$.spec.split(':').pop();
 
-  // Get the latest version from the AdGem GitHub releases
   const response = await axios.get('https://api.github.com/repos/AdGem/Android-SDK/releases/latest', {
     headers: {
       'Accept': 'application/vnd.github+json',
@@ -33,7 +31,6 @@ async function checkAdGemSdkUpdates() {
   latestVersion = latestVersion.replace(/^v/, ''); // Remove leading 'v'
 
   if (latestVersion !== currentVersion) {
-    // Update the AdGemDependencies.xml with the new version
     xml.dependencies.androidPackages[0].androidPackage[0].$.spec = `com.adgem:adgem-android:${latestVersion}`;
     const builder = new xml2js.Builder();
     const updatedXmlContent = builder.buildObject(xml);
@@ -43,4 +40,39 @@ async function checkAdGemSdkUpdates() {
   console.log(latestVersion);
 }
 
-checkAdGemSdkUpdates();
+async function checkOwnRepoUpdates() {
+  const packageJsonPath = path.join(__dirname, '../package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const currentVersion = packageJson.version;
+
+  const response = await axios.get('https://api.github.com/repos/AdGem/adgem-sdk-unity-package/releases/latest', {
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'Authorization': `Bearer ${GITHUB_TOKEN}`,
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
+  });
+
+  let latestVersion = response.data.tag_name;
+  latestVersion = latestVersion.replace(/^v/, ''); // Remove leading 'v'
+
+  if (latestVersion !== currentVersion) {
+    packageJson.version = latestVersion;
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+  }
+
+  console.log(latestVersion);
+}
+
+console.log('Checking for updates...');
+console.log('Github Token:', GITHUB_TOKEN);
+console.log('Check Type:', CHECK_TYPE);
+
+if (CHECK_TYPE === 'external') {
+  checkExternalUpdates();
+} else if (CHECK_TYPE === 'self') {
+  checkOwnRepoUpdates();
+} else {
+  console.error('Error: Invalid check type. Use "external" or "self".'); // We'll add separate checks for android vs ios later
+  process.exit(1);
+}


### PR DESCRIPTION
### Changes
- Update the `check-for-updates.js` script file to check for both internal and external versions to update our references to
- Update the GitHub Workflows that were referencing this script
- Add a GitHub Workflow that separately checks for self-owned repository release versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow to automate updating the Unity package URL in the README file and package.json.
	- Added functionality to specify the type of update check (external or self) for SDK updates.
	- Added a step to update the Android Manifest File with the latest SDK version.

- **Bug Fixes**
	- Enhanced error handling in the update checking process.

- **Chores**
	- Updated workflows to improve automation and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->