### PR TITLE
build: update Unity package URL to version 1.6.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The AdGem SDK for the Unity Package Manager.
 Install the AdGem Unity SDK package via the [Unity Package Manager using the following Git URL](https://docs.unity3d.com/Manual/upm-ui-giturl.html):
 
 ```
-https://github.com/AdGem/adgem-sdk-unity-package.git#1.4.0
+https://github.com/AdGem/adgem-sdk-unity-package.git#1.6.13
 ```
 
 In the Editor, you can access the Package Manager window through the **Window > Package Manager** menu.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.adgem.unity",
-  "version": "1.4.0",
+  "version": "1.6.13",
   "displayName": "AdGem Unity",
   "description": "AdGem SDK for Unity",
   "unity": "2019.4",


### PR DESCRIPTION
This PR updates the Unity package URL in the README.md file to the latest version(v1.6.13).